### PR TITLE
Npm boilerplates

### DIFF
--- a/Source/boilerPlates/BoilerPlate.js
+++ b/Source/boilerPlates/BoilerPlate.js
@@ -116,7 +116,7 @@ export class BoilerPlate {
             language: this.#language,
             description: this.#description,
             type: this.#type,
-            dependencies: this.#dependencies,
+            dependencies: this.#dependencies.map(_ => _.toJson()) || [],
             path: this.#path,
             pathsNeedingBinding: this.#pathsNeedingBinding,
             filesNeedingBinding: this.#filesNeedingBinding

--- a/Source/boilerPlates/BoilerPlatesManager.js
+++ b/Source/boilerPlates/BoilerPlatesManager.js
@@ -162,7 +162,7 @@ export class BoilerPlatesManager {
         
         boilerPlatesPaths.forEach(boilerPlatePath => {
             let boilerPlateObject = JSON.parse(this.#fileSystem.readFileSync(boilerPlatePath, 'utf8'));
-            boilerPlates.push(this.parseBoilerPlate(boilerPlateObject, boilerPlatePath));
+            boilerPlates.push(this.#parseBoilerPlate(boilerPlateObject, boilerPlatePath));
         });
         return boilerPlates;
     }

--- a/Source/boilerPlates/BoilerPlatesManager.js
+++ b/Source/boilerPlates/BoilerPlatesManager.js
@@ -60,12 +60,11 @@ export class BoilerPlatesManager {
         this.#folders = folders;
         this.#fileSystem = fileSystem;
         this.#git = git;
-
-        this.#createLocalBoilerPlatesFolder();
-
-        this.#logger = logger;
         this.#handlebars = handlebars;
-        this.readBoilerPlates();
+        this.#logger = logger;
+
+        this.#boilerPlates = undefined;
+        this.#createLocalBoilerPlatesFolder();
     }
     /**
      * Gets base path for boiler plates
@@ -80,6 +79,7 @@ export class BoilerPlatesManager {
      * @returns {BoilerPlate[]} Available boiler plates
      */
     get boilerPlates() {
+        if (!this.#boilerPlates) this.readBoilerPlates();
         return this.#boilerPlates;
     }
     /**
@@ -96,7 +96,7 @@ export class BoilerPlatesManager {
      * @returns {BoilerPlate[]} Available boiler plates for the language
      */
     boilerPlatesByLanguage(language) {
-        return this.#boilerPlates.filter(boilerPlate => boilerPlate.language == language);
+        return this.boilerPlates.filter(boilerPlate => boilerPlate.language == language);
     }
 
     /**
@@ -105,7 +105,7 @@ export class BoilerPlatesManager {
      * @returns {BoilerPlate[]} Available boiler plates for the type
      */
     boilerPlatesByType(type) {
-        return this.#boilerPlates.filter(boilerPlate => boilerPlate.type == type);
+        return this.boilerPlates.filter(boilerPlate => boilerPlate.type == type);
     }
 
     /**
@@ -115,7 +115,7 @@ export class BoilerPlatesManager {
      * @returns {BoilerPlate[]} Available boiler plates for the language
      */
     boilerPlatesByLanguageAndType(language, type) {
-        return this.#boilerPlates.filter(boilerPlate => boilerPlate.language == language && boilerPlate.type == type);
+        return this.boilerPlates.filter(boilerPlate => boilerPlate.language == language && boilerPlate.type == type);
     }
 
     /**
@@ -245,7 +245,7 @@ export class BoilerPlatesManager {
      * @returns {boolean} True if there are, false if not
      */
     get hasBoilerPlates() {
-        return this.#boilerPlates.length > 0;
+        return this.#boilerPlates && this.#boilerPlates.length > 0;
     }
     /**
      * Parses a boilerplate read from a boilerplate package correctly

--- a/Source/boilerPlates/BoilerPlatesManager.js
+++ b/Source/boilerPlates/BoilerPlatesManager.js
@@ -12,7 +12,7 @@ import { Folders } from '../Folders';
 import { ConfigManager } from '../configuration/ConfigManager';
 import { ArtifactTemplate } from '../artifacts/ArtifactTemplate';
 
-const boilerPlateFolder = 'boiler-plates';
+const boilerPlateFolder = 'boilerplates';
 
 const binaryFiles = [
     '.jpg',
@@ -66,17 +66,6 @@ export class BoilerPlatesManager {
         this.#createLocalBoilerPlatesFolder();
         
         this.#warnIfUsingOldSystem();
-    }
-    #warnIfUsingOldSystem() {
-        const filePath = path.join(this.#configManager.centralFolderLocation, 'boiler-plates.json');
-        if (this.#fileSystem.existsSync(filePath)) {
-            throw new Error(
-`I see that there has been a long time since you've updated the dolittle tooling.
-
-Please delete the file ${filePath} and all the boilerplates in ${this.localBoilerPlateLocation} that is not your own custom boilerplate.
-`
-            );
-        }
     }
     /**
      * Gets base path for boiler plates
@@ -258,6 +247,18 @@ Please delete the file ${filePath} and all the boilerplates in ${this.localBoile
      */
     get hasBoilerPlates() {
         return this.#boilerPlates && this.#boilerPlates.length > 0;
+    }
+
+    #warnIfUsingOldSystem() {
+        const filePath = path.join(this.#configManager.centralFolderLocation, 'boiler-plates.json');
+        if (this.#fileSystem.existsSync(filePath)) {
+            throw new Error(
+`I see that there has been a long time since you've updated the dolittle tooling.
+
+Please delete the file ${filePath} and all the boilerplates in ${this.localBoilerPlateLocation} that is not your own custom boilerplate.
+`
+            );
+        }
     }
     /**
      * Parses a boilerplate read from a boilerplate package correctly

--- a/Source/boilerPlates/BoilerPlatesManager.js
+++ b/Source/boilerPlates/BoilerPlatesManager.js
@@ -61,13 +61,12 @@ export class BoilerPlatesManager {
         this.#fileSystem = fileSystem;
         this.#git = git;
 
-        this.#folders.makeFolderIfNotExists(this.localBoilerPlateLocation);
+        this.#createLocalBoilerPlatesFolder();
 
         this.#logger = logger;
         this.#handlebars = handlebars;
         this.readBoilerPlates();
     }
-
     /**
      * Gets base path for boiler plates
      * @returns {string} Base path of boiler plates
@@ -301,6 +300,17 @@ export class BoilerPlatesManager {
             boilerPlateObject.path,
             boilerPlateObject.pathsNeedingBinding ,
             boilerPlateObject.filesNeedingBinding
+        );
+    }
+    /**
+     * Creates the local boilerplates folder in ~/.dolittle if not exists
+     */
+    #createLocalBoilerPlatesFolder() {
+        this.#folders.makeFolderIfNotExists(this.localBoilerPlateLocation);
+        require('fs-extra').writeFileSync(path.join(this.localBoilerPlateLocation, 'README'), 
+`This is a folder where you can have your own boilerplates.
+
+To be documented...`
         );
     }
 }

--- a/Source/boilerPlates/BoilerPlatesManager.js
+++ b/Source/boilerPlates/BoilerPlatesManager.js
@@ -65,6 +65,19 @@ export class BoilerPlatesManager {
 
         this.#boilerPlates = undefined;
         this.#createLocalBoilerPlatesFolder();
+        
+        this.#warnIfUsingOldSystem();
+    }
+    #warnIfUsingOldSystem() {
+        const filePath = path.join(this.#configManager.centralFolderLocation, 'boiler-plates.json');
+        if (this.#fileSystem.existsSync(filePath)) {
+            throw new Error(
+`I see that there has been a long time since you've updated the dolittle tooling.
+
+Please delete the file ${filePath} and all the boilerplates in ${this.localBoilerPlateLocation} that is not your own custom boilerplate.
+`
+            );
+        }
     }
     /**
      * Gets base path for boiler plates

--- a/Source/boilerPlates/BoilerPlatesManager.js
+++ b/Source/boilerPlates/BoilerPlatesManager.js
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import npm from 'npm';
 import path from 'path';
 import { BoilerPlate } from './BoilerPlate';
 import { getFileNameAndExtension, getFileDirPath } from '../helpers';
@@ -193,7 +192,7 @@ Please delete the file ${filePath} and all the boilerplates in ${this.localBoile
         return folders;
     }
     /**
-     * Installs the npm package with given packagename 
+     * Installs the npm package with given package name 
      *
      * @param string packageName
      * @memberof BoilerPlatesManager

--- a/Source/index.js
+++ b/Source/index.js
@@ -55,6 +55,7 @@ export {Guid} from './Guid';
 export {HttpWrapper} from './HttpWrapper';
 
 export const dolittleConfigDefault = {
+    externalBoilerplates: [],
     any: {
         concepts: 'Concepts',
         domain: 'Domain',
@@ -68,6 +69,7 @@ export const dolittleConfigDefault = {
         read: 'Read'
     }
 };
+
 
 export const logger = winston.createLogger({
     level: 'info',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@dolittle/boilerplates.application": "^1.0.0",
     "@dolittle/boilerplates.artifact-templates": "^1.0.0",
     "@dolittle/boilerplates.bounded-context.csharp": "^1.0.0",
+    "@dolittle/boilerplates.bounded-context.veracity.csharp": "^1.0.0",
     "fs-extra": "^7.0.0",
     "handlebars": "^4.0.12",
     "npm": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@dolittle/boilerplates.bounded-context.csharp": "^1.0.0",
     "fs-extra": "^7.0.0",
     "handlebars": "^4.0.12",
+    "npm": "^6.5.0",
     "rc": "^1.2.8",
     "shelljs": "^0.8.2",
     "simple-git": "^1.96.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@dolittle/boilerplates.bounded-context.veracity.csharp": "^1.0.0",
     "fs-extra": "^7.0.0",
     "handlebars": "^4.0.12",
-    "npm": "^6.5.0",
     "rc": "^1.2.8",
     "shelljs": "^0.8.2",
     "simple-git": "^1.96.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "@dolittle/build": "~6.2.1"
   },
   "dependencies": {
+    "@dolittle/boilerplates.application": "^1.0.0",
+    "@dolittle/boilerplates.artifact-templates": "^1.0.0",
+    "@dolittle/boilerplates.bounded-context.csharp": "^1.0.0",
     "fs-extra": "^7.0.0",
     "handlebars": "^4.0.12",
     "rc": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolittle/tooling.common",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "Common tools for dolittle tooling",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Boilerplates are now npm packages (we have a set of our own boilerplate packages). You can also still have local boilerplates. 

Tooling.common has a direct dependency to our own boilerplate packages.

There are still some features that are not implemented yet, but they are not important for the time being. 

Specs have not been adjusted yet