### PR TITLE
Fix plugin boilerplates

### DIFF
--- a/Source/boilerplates/online/checkBoilerplates.ts
+++ b/Source/boilerplates/online/checkBoilerplates.ts
@@ -50,7 +50,6 @@ async function getOutOfDatePackages(locallyInstalledPackages: {name: string, ver
             await latestPackageFinder.find(pkg.name, boilerplatePackageKeyword)
                 .then(packageJson => {
                     if (packageJson === null) {
-                        busyIndicator.fail(`'${pkg.name}' is not a boilerplate`);
                         busyIndicator = busyIndicator.createNew().start();
                     }
                     else {

--- a/Source/common/globals.ts
+++ b/Source/common/globals.ts
@@ -3,14 +3,15 @@
 *  Licensed under the MIT License. See LICENSE in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 import { IInitializer, Initializer, ProjectConfig } from './internal';
-import { boilerplates, boilerplatesLoader } from '@dolittle/tooling.common.boilerplates';
+import { boilerplates, boilerplatesLoader, boilerplateDiscoverers } from '@dolittle/tooling.common.boilerplates';
 import { commandManager, providerRegistrators, ICanRegisterProviders } from '@dolittle/tooling.common.commands';
-import { plugins } from '@dolittle/tooling.common.plugins';
+import { plugins, onlineDolittlePluginsFinder } from '@dolittle/tooling.common.plugins';
 import { loggers } from '@dolittle/tooling.common.logging';
 import { ProviderRegistrator } from './internal';
 import { contexts } from '@dolittle/tooling.common.login';
+import { connectionChecker, npmPackageDownloader } from '@dolittle/tooling.common.packages';
 
-export let initializer: IInitializer = new Initializer(providerRegistrators, commandManager, plugins, boilerplates, boilerplatesLoader, loggers);
+export let initializer: IInitializer = new Initializer(providerRegistrators, commandManager, plugins, boilerplates, boilerplatesLoader, boilerplateDiscoverers, onlineDolittlePluginsFinder, connectionChecker, npmPackageDownloader, loggers);
 
 const providerRegistrator: ICanRegisterProviders = new ProviderRegistrator(commandManager, initializer, contexts, loggers);
 providerRegistrators.addRegistrators(providerRegistrator);


### PR DESCRIPTION
Fixes multiple issues that was apparent in the CLI:

- Automatically download default plugins that are not present, not prompt the user to download. It will also print out a list of the default plugins that could not be downloaded.
- When checking boilerplates it will no longer print errors for boilerplates inside plugins.
- When installing plugins it will also initialize the boilerplates system 

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1157798784273948)
